### PR TITLE
Add support for all global queues

### DIFF
--- a/Source/Functions.swift
+++ b/Source/Functions.swift
@@ -39,7 +39,3 @@ public func dispatch(queue queueType: DispatchQueue = .Main, closure: () -> Void
     closure()
   })
 }
-
-dispatch(queue: .Custom(myQueue)) {
-
-}

--- a/Source/Functions.swift
+++ b/Source/Functions.swift
@@ -13,7 +13,26 @@ public func localizedString(key: String, comment: String? = nil) -> String {
   return NSLocalizedString(key, comment: (comment != nil) ? comment! : key)
 }
 
-public func dispatch(queue: dispatch_queue_t = dispatch_get_main_queue(), closure: () -> Void) {
+public enum DispatchQueue {
+  case Main, Interactive, Initiated, Utility, Background
+}
+
+public func dispatch(queue queueType: DispatchQueue = .Main, closure: () -> Void) {
+  let queue: dispatch_queue_t
+
+  switch queueType {
+    case .Main:
+      queue = dispatch_get_main_queue()
+    case .Interactive:
+      queue = dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0)
+    case .Initiated:
+      queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0)
+    case .Utility:
+      queue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0)
+    case .Background:
+      queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)
+  }
+
   dispatch_async(queue, {
     closure()
   })

--- a/Source/Functions.swift
+++ b/Source/Functions.swift
@@ -14,7 +14,7 @@ public func localizedString(key: String, comment: String? = nil) -> String {
 }
 
 public enum DispatchQueue {
-  case Main, Interactive, Initiated, Utility, Background
+  case Main, Interactive, Initiated, Utility, Background, Custom(dispatch_queue_t)
 }
 
 public func dispatch(queue queueType: DispatchQueue = .Main, closure: () -> Void) {
@@ -31,9 +31,15 @@ public func dispatch(queue queueType: DispatchQueue = .Main, closure: () -> Void
       queue = dispatch_get_global_queue(QOS_CLASS_UTILITY, 0)
     case .Background:
       queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)
+    case .Custom(let userQueue):
+      queue = userQueue
   }
 
   dispatch_async(queue, {
     closure()
   })
+}
+
+dispatch(queue: .Custom(myQueue)) {
+
 }


### PR DESCRIPTION
This PR adds some functionality to `dispatch`.
Now you can select between all global queues by just passing an enum value;

It still defaults to `.Main` so the public API does not change.

```swift
# Main queue
dispatch {}

# Interactive
dispatch(queue: .Interactive) {}

# Interactive
dispatch(queue: .Initiated) {}

# Interactive
dispatch(queue: .Utility) {}

# Background
dispatch(queue: .Background) {}
```

As an added bonus, if you need your own custom queue you can just do the following;

```swift
# Custom
dispatch(queue: .Custom(myQueue)) {}
```