### PR TITLE
Feature/split string extension

### DIFF
--- a/Source/Shared/Extensions/String+CoreFoundation.swift
+++ b/Source/Shared/Extensions/String+CoreFoundation.swift
@@ -13,4 +13,10 @@ public extension String {
 
     return self.substringToIndex(self.startIndex.advancedBy(length)) + suffix
   }
+
+  func split(delimiter: Character) -> [String] {
+    return characters
+      .split { $0 == delimiter }
+      .map(String.init)
+  }
 }

--- a/Source/Shared/Extensions/String+CoreFoundation.swift
+++ b/Source/Shared/Extensions/String+CoreFoundation.swift
@@ -14,9 +14,7 @@ public extension String {
     return self.substringToIndex(self.startIndex.advancedBy(length)) + suffix
   }
 
-  func split(delimiter: Character) -> [String] {
-    return characters
-      .split { $0 == delimiter }
-      .map(String.init)
+  func split(delimiter: String) -> [String] {
+    return componentsSeparatedByString(delimiter)
   }
 }

--- a/Tests/Shared/TestStringExtensionCoreFoundation.swift
+++ b/Tests/Shared/TestStringExtensionCoreFoundation.swift
@@ -24,4 +24,10 @@ class StringExtensionCoreFoundationTests: XCTestCase {
     XCTAssertEqual(stringB, stringC)
     XCTAssertEqual(stringC, stringA.stringByReplacingOccurrencesOfString("-", withString: ":"))
   }
+
+  func testStringSplit() {
+    let testString = "root/path/file"
+    let parts = testString.split("/")
+    XCTAssertEqual(parts.count, 3)
+  }
 }


### PR DESCRIPTION
With this PR, you can easily split up `String`’s into multiple parts by calling `split()`.

```swift
"root/path/file".split("/")
// ["root", "path", "file"]
```