### PR TITLE
Add collection and table view sugars

### DIFF
--- a/Source/iOS/Extensions/UICollectionView+Indexes.swift
+++ b/Source/iOS/Extensions/UICollectionView+Indexes.swift
@@ -32,4 +32,13 @@ public extension UICollectionView {
         completion?()
     }
   }
+
+  func reloadSection(index: Int = 0, completion: (() -> Void)? = nil) {
+    performBatchUpdates({ [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.reloadSections(NSIndexSet(index: index))
+      }) { _ in
+        completion?()
+    }
+  }
 }

--- a/Source/iOS/Extensions/UICollectionView+Indexes.swift
+++ b/Source/iOS/Extensions/UICollectionView+Indexes.swift
@@ -23,7 +23,7 @@ public extension UICollectionView {
     }
   }
 
-  func remove(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {
+  func delete(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {
     let indexPaths = indexes.map { NSIndexPath(forItem: $0, inSection: section) }
     performBatchUpdates({ [weak self] in
       guard let weakSelf = self else { return }

--- a/Source/iOS/Extensions/UICollectionView+Indexes.swift
+++ b/Source/iOS/Extensions/UICollectionView+Indexes.swift
@@ -1,0 +1,35 @@
+import UIKit
+
+public extension UICollectionView {
+
+  func insert(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {
+    let indexPaths = indexes.map { NSIndexPath(forItem: $0, inSection: section) }
+
+    performBatchUpdates({ [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.insertItemsAtIndexPaths(indexPaths)
+      }) { _ in
+        completion?()
+    }
+  }
+
+  func reload(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {
+    let indexPaths = indexes.map { NSIndexPath(forItem: $0, inSection: section) }
+    performBatchUpdates({ [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.reloadItemsAtIndexPaths(indexPaths)
+      }) { _ in
+        completion?()
+    }
+  }
+
+  func remove(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {
+    let indexPaths = indexes.map { NSIndexPath(forItem: $0, inSection: section) }
+    performBatchUpdates({ [weak self] in
+      guard let weakSelf = self else { return }
+      weakSelf.deleteItemsAtIndexPaths(indexPaths)
+      }) { _ in
+        completion?()
+    }
+  }
+}

--- a/Source/iOS/Extensions/UITableView+Indexes.swift
+++ b/Source/iOS/Extensions/UITableView+Indexes.swift
@@ -23,7 +23,7 @@ public extension UITableView {
     }
   }
 
-  func performUpdates(@noescape closure: () -> Void) {
+  private func performUpdates(@noescape closure: () -> Void) {
     beginUpdates()
     closure()
     endUpdates()

--- a/Source/iOS/Extensions/UITableView+Indexes.swift
+++ b/Source/iOS/Extensions/UITableView+Indexes.swift
@@ -1,0 +1,25 @@
+import UIKit
+
+public extension UITableView {
+
+  func insert(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .None) {
+    let indexPaths = indexes.map { NSIndexPath(forRow: $0, inSection: section) }
+    performUpdates { insertRowsAtIndexPaths(indexPaths, withRowAnimation: .None) }
+  }
+
+  func reload(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .None) {
+    let indexPaths = indexes.map { NSIndexPath(forRow: $0, inSection: section) }
+    performUpdates { reloadRowsAtIndexPaths(indexPaths, withRowAnimation: .None) }
+  }
+
+  func remove(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .None) {
+    let indexPaths = indexes.map { NSIndexPath(forRow: $0, inSection: section) }
+    performUpdates { deleteRowsAtIndexPaths(indexPaths, withRowAnimation: .None) }
+  }
+
+  func performUpdates(@noescape closure: () -> Void) {
+    beginUpdates()
+    closure()
+    endUpdates()
+  }
+}

--- a/Source/iOS/Extensions/UITableView+Indexes.swift
+++ b/Source/iOS/Extensions/UITableView+Indexes.swift
@@ -17,6 +17,12 @@ public extension UITableView {
     performUpdates { deleteRowsAtIndexPaths(indexPaths, withRowAnimation: .None) }
   }
 
+  func reloadSection(section: Int = 0, animation: UITableViewRowAnimation = .None) {
+    performUpdates {
+      reloadSections(NSIndexSet(index: section), withRowAnimation: .Automatic)
+    }
+  }
+
   func performUpdates(@noescape closure: () -> Void) {
     beginUpdates()
     closure()

--- a/Sugar.xcodeproj/project.pbxproj
+++ b/Sugar.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		BD0E01C91C3BCFD50092C477 /* GrandCentralDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0E01C71C3BCFD50092C477 /* GrandCentralDispatch.swift */; };
 		BD0E01CB1C3BCFEF0092C477 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0E01CA1C3BCFEF0092C477 /* Localization.swift */; };
 		BD0E01CC1C3BCFEF0092C477 /* Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0E01CA1C3BCFEF0092C477 /* Localization.swift */; };
+		BD0E01CE1C3BD7AC0092C477 /* UITableView+Indexes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0E01CD1C3BD7AC0092C477 /* UITableView+Indexes.swift */; };
+		BD0E01D11C3BD93C0092C477 /* UICollectionView+Indexes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0E01D01C3BD93C0092C477 /* UICollectionView+Indexes.swift */; };
 		BD18D5A21C391926002E6547 /* TestThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD18D5A11C391926002E6547 /* TestThen.swift */; };
 		BD37B4EF1C2C07220069CD4A /* TestUnitTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD37B4EE1C2C07220069CD4A /* TestUnitTesting.swift */; };
 		BD37B4F01C2C07220069CD4A /* TestUnitTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD37B4EE1C2C07220069CD4A /* TestUnitTesting.swift */; };
@@ -67,6 +69,8 @@
 /* Begin PBXFileReference section */
 		BD0E01C71C3BCFD50092C477 /* GrandCentralDispatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrandCentralDispatch.swift; sourceTree = "<group>"; };
 		BD0E01CA1C3BCFEF0092C477 /* Localization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Localization.swift; sourceTree = "<group>"; };
+		BD0E01CD1C3BD7AC0092C477 /* UITableView+Indexes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Indexes.swift"; sourceTree = "<group>"; };
+		BD0E01D01C3BD93C0092C477 /* UICollectionView+Indexes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Indexes.swift"; sourceTree = "<group>"; };
 		BD18D5A11C391926002E6547 /* TestThen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestThen.swift; sourceTree = "<group>"; };
 		BD37B4EE1C2C07220069CD4A /* TestUnitTesting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUnitTesting.swift; sourceTree = "<group>"; };
 		BDA447891C2946BB003FDEAD /* Sugar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Sugar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -155,6 +159,8 @@
 			isa = PBXGroup;
 			children = (
 				BDA447A41C29470D003FDEAD /* UIView+Optimize.swift */,
+				BD0E01CD1C3BD7AC0092C477 /* UITableView+Indexes.swift */,
+				BD0E01D01C3BD93C0092C477 /* UICollectionView+Indexes.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -481,12 +487,14 @@
 			files = (
 				BDA447B61C294723003FDEAD /* Array+Queueable.swift in Sources */,
 				BDA447B81C294723003FDEAD /* String+URLStringConvertible.swift in Sources */,
+				BD0E01CE1C3BD7AC0092C477 /* UITableView+Indexes.swift in Sources */,
 				BDA447BA1C294723003FDEAD /* Operator.swift in Sources */,
 				BD0E01C81C3BCFD50092C477 /* GrandCentralDispatch.swift in Sources */,
 				BDA447BB1C294723003FDEAD /* TypeAlias.swift in Sources */,
 				BDA447BC1C294723003FDEAD /* UITesting.swift in Sources */,
 				BDA447BD1C294723003FDEAD /* UnitTesting.swift in Sources */,
 				BDAF15621C3917110008A5D6 /* Then.swift in Sources */,
+				BD0E01D11C3BD93C0092C477 /* UICollectionView+Indexes.swift in Sources */,
 				BDA447B21C29471C003FDEAD /* Application.swift in Sources */,
 				BDA447B31C29471C003FDEAD /* UIView+Optimize.swift in Sources */,
 				BD0E01CB1C3BCFEF0092C477 /* Localization.swift in Sources */,


### PR DESCRIPTION
This PR adds some sugars for inserting, updating and deleting indexes on a `UITableView` or `UICollectionView`.

```swift
public extension UICollectionView {
  func insert(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {}
  func reload(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {}
  func remove(indexes: [Int], section: Int = 0, completion: (() -> Void)? = nil) {}
  func reloadSection(index: Int = 0, completion: (() -> Void)? = nil) {}
}

public extension UITableView {

  func insert(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .None) {}
  func reload(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .None) {}
  func remove(indexes: [Int], section: Int = 0, animation: UITableViewRowAnimation = .None) {}
  func reloadSection(section: Int = 0, animation: UITableViewRowAnimation = .None) {}
  private func performUpdates(@noescape closure: () -> Void) {}
}
```

If you only have one section and no completion you could just run;

```swift
tableView.insert([1,2,3])
```