### PR TITLE
Refactor split method on String

### DIFF
--- a/Source/Shared/Extensions/String+CoreFoundation.swift
+++ b/Source/Shared/Extensions/String+CoreFoundation.swift
@@ -15,6 +15,7 @@ public extension String {
   }
 
   func split(delimiter: String) -> [String] {
-    return componentsSeparatedByString(delimiter)
+    let components = componentsSeparatedByString(delimiter)
+    return components != [""] ? components : []
   }
 }


### PR DESCRIPTION
This PR refactors `.split` on `String`.
If `componentsSeparatedByString` in unable to split the current target into components it
will return `[]` instead of `[""]`.