### PR TITLE
Refactor String.truncate

### DIFF
--- a/Source/Shared/Extensions/String+CoreFoundation.swift
+++ b/Source/Shared/Extensions/String+CoreFoundation.swift
@@ -15,6 +15,7 @@ public extension String {
   }
 
   func split(delimiter: String) -> [String] {
-    return componentsSeparatedByString(delimiter)
+    let components = componentsSeparatedByString(delimiter)
+    return components != [""] ? components : []
   }
 }

--- a/Source/Shared/Extensions/String+CoreFoundation.swift
+++ b/Source/Shared/Extensions/String+CoreFoundation.swift
@@ -9,9 +9,9 @@ public extension String {
   }
 
   func truncate(length: Int, suffix: String = "...") -> String {
-    guard self.characters.count > length else { return self }
-
-    return self.substringToIndex(self.startIndex.advancedBy(length)) + suffix
+    return self.characters.count > length
+      ? self.substringToIndex(self.startIndex.advancedBy(length)) + suffix
+      : self
   }
 
   func split(delimiter: String) -> [String] {


### PR DESCRIPTION
It felt a bit overkill to have an early return in such a small method.
Now the statement is a part of the `return` which renders it equally clear.

```swift
  func truncate(length: Int, suffix: String = "...") -> String {
    return self.characters.count > length
      ? self.substringToIndex(self.startIndex.advancedBy(length)) + suffix
      : self
  }
```

https://github.com/hyperoslo/Sugar/pull/29 should be merged before this PR.