### PR TITLE
Improve localizedString method

### DIFF
--- a/Source/Shared/Localization.swift
+++ b/Source/Shared/Localization.swift
@@ -1,5 +1,9 @@
 import Foundation
 
-public func localizedString(key: String, comment: String? = nil) -> String {
-  return NSLocalizedString(key, comment: (comment != nil) ? comment! : key)
+public func LocalizedString(key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil) -> String {
+  if let bundleClass = bundleClass {
+    return NSLocalizedString(key, bundle: NSBundle(forClass: bundleClass), comment: (comment != nil) ? comment! : key)
+  } else {
+    return NSLocalizedString(key, bundle: NSBundle.mainBundle(), comment: (comment != nil) ? comment! : key)
+  }
 }

--- a/Source/Shared/Localization.swift
+++ b/Source/Shared/Localization.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public func LocalizedString(key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil) -> String {
+public func localizedString(key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil) -> String {
   if let bundleClass = bundleClass {
     return NSLocalizedString(key, bundle: NSBundle(forClass: bundleClass), comment: (comment != nil) ? comment! : key)
   } else {


### PR DESCRIPTION
This PR refactors the `localizedString` method so that you can specify which bundle you would like to open the string from.
You do this by sending in the class of the current UI component using the string.

```swift
UILabel.text = localizedString("Contact.Email", self.classForCoder)
```