### PR TITLE
Added isIPhone, isIPad, isSimulator methods to UIDevice+Model

### DIFF
--- a/Source/iOS/Extensions/UIDevice+Model.swift
+++ b/Source/iOS/Extensions/UIDevice+Model.swift
@@ -33,4 +33,16 @@ public extension UIDevice {
 
     return result
   }
+    
+    public static func isIPhone() -> Bool {
+        return UIDevice().userInterfaceIdiom == .Phone
+    }
+
+    public static func isIPad() -> Bool {
+        return UIDevice().userInterfaceIdiom == .Pad
+    }
+
+    public static func isSimulator() -> Bool {
+        return Simulator.isRunning
+    }
 }

--- a/Source/iOS/Extensions/UIDevice+Model.swift
+++ b/Source/iOS/Extensions/UIDevice+Model.swift
@@ -34,11 +34,11 @@ public extension UIDevice {
     return result
   }
     
-    public static func isIPhone() -> Bool {
+    public static func isPhone() -> Bool {
         return UIDevice().userInterfaceIdiom == .Phone
     }
 
-    public static func isIPad() -> Bool {
+    public static func isPad() -> Bool {
         return UIDevice().userInterfaceIdiom == .Pad
     }
 


### PR DESCRIPTION
1. Added function `isIPhone` and `isIPad`.
When working on Universal application these are very useful.

2. Added function `isSimulator`
This was already present in `Sugar` via `Simulator`. Just added convenient method here.