### PR TITLE
Implement localized string with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ And `.Custom()` for your own dispatch queues.
 
 ```swift
 let string = localizedString("My Profile")
+let formattedString = localizedString(key: "%d numbers", arguments: 10) 
 ```
 
 Swift access (pun intended) to `NSLocalizedString`, you will get more valid auto completion

--- a/Source/Shared/Localization.swift
+++ b/Source/Shared/Localization.swift
@@ -7,3 +7,9 @@ public func localizedString(key: String, _ bundleClass: AnyClass? = nil, comment
     return NSLocalizedString(key, bundle: NSBundle.mainBundle(), comment: (comment != nil) ? comment! : key)
   }
 }
+
+public func localizeString(key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil, arguments: CVarArgType...) -> String {
+  return withVaList(arguments) {
+    NSString(format: localizedString(key, bundleClass, comment: comment), locale: NSLocale.currentLocale(), arguments: $0)
+    } as String
+}

--- a/Source/Shared/Localization.swift
+++ b/Source/Shared/Localization.swift
@@ -8,7 +8,7 @@ public func localizedString(key: String, _ bundleClass: AnyClass? = nil, comment
   }
 }
 
-public func localizeString(key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil, arguments: CVarArgType...) -> String {
+public func localizedString(key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil, arguments: CVarArgType...) -> String {
   return withVaList(arguments) {
     NSString(format: localizedString(key, bundleClass, comment: comment), locale: NSLocale.currentLocale(), arguments: $0)
     } as String


### PR DESCRIPTION
Now you can localize formatted string with arguments:
`localizedString(key: "%d numbers", arguments: 10)` 