### PR TITLE
Contains method in Range

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Sugar is a sweetener for your Cocoa implementations.
   * [Grand Central Dispatch](#grand-central-dispatch)
   * [Localization](#localization)
   * [Operators](#operators)
+  * [Range](#range)
   * [Regex](#regex)
   * [Shared Extensions](#shared-extensions)
     * [Queueable](#queueable)
@@ -177,7 +178,7 @@ And `.Custom()` for your own dispatch queues.
 
 ```swift
 let string = localizedString("My Profile")
-let formattedString = localizedString(key: "%d numbers", arguments: 10) 
+let formattedString = localizedString(key: "%d numbers", arguments: 10)
 ```
 
 Swift access (pun intended) to `NSLocalizedString`, you will get more valid auto completion
@@ -192,6 +193,15 @@ url ?= NSURL(string: "\\/http")
 ```
 
 The `?=` only assigns values if the right is not nil.
+
+### Range
+
+```swift
+let acceptable = 200..<300
+if acceptable.contains(response.statusCode) {
+  // Status code is between 200 and 299.
+}
+```
 
 ### Regex
 

--- a/Source/Shared/Extensions/Range+Contains.swift
+++ b/Source/Shared/Extensions/Range+Contains.swift
@@ -1,4 +1,4 @@
-import UIKit
+import Foundation
 
 extension Range {
 

--- a/Source/iOS/Extensions/Range+Contains.swift
+++ b/Source/iOS/Extensions/Range+Contains.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+extension Range {
+
+  func contains(value: Element) -> Bool {
+    for x in self {
+      if x == value { return true }
+    }
+
+    return false
+  }
+}


### PR DESCRIPTION
I was doing some Networking and wanted to check if the status code was in a range, did this tiny thing. You call it like this:

```swift
let OK = 200..<300
OK.contains(response.statusCode)
```

@hyperoslo/malibu