### PR TITLE
Rename method to fix compiler error with Swift 3.0.1

### DIFF
--- a/Source/Shared/Localization.swift
+++ b/Source/Shared/Localization.swift
@@ -8,8 +8,8 @@ public func localizedString(_ key: String, _ bundleClass: AnyClass? = nil, comme
   }
 }
 
-public func localizedString(_ key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil, arguments: CVarArg...) -> String {
+public func localizeString(_ key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil, arguments: CVarArg...) -> String {
   return withVaList(arguments) {
-    (NSString(format: localizedString(key, bundleClass, comment: comment), locale: Locale.current, arguments: $0) as String)
+    (NSString(format: localizeString(key, bundleClass, comment: comment), locale: Locale.current, arguments: $0) as String)
     } as String
 }


### PR DESCRIPTION
This PR fixes a compiler error that is introduced with Swift 3.0.1.