### PR TITLE
Remove localizeString function

### DIFF
--- a/Source/Shared/Localization.swift
+++ b/Source/Shared/Localization.swift
@@ -7,9 +7,3 @@ public func localizedString(_ key: String, _ bundleClass: AnyClass? = nil, comme
     return NSLocalizedString(key, bundle: Bundle.main, comment: (comment != nil) ? comment! : key)
   }
 }
-
-public func localizeString(_ key: String, _ bundleClass: AnyClass? = nil, comment: String? = nil, arguments: CVarArg...) -> String {
-  return withVaList(arguments) {
-    (NSString(format: localizeString(key, bundleClass, comment: comment), locale: Locale.current, arguments: $0) as String)
-    } as String
-}


### PR DESCRIPTION
As of https://github.com/hyperoslo/Sugar/pull/90

I see that these 2 methods could cause confusion, and we can get infinite recursive calls within `localizeString`, so it's best to remove this.

Users can use the built in Swift function to create string`String(format: localizedString("some_key", arg[0], arg[1])`, it handles number of arguments for us