### PR TITLE
Add Constraint to handle constraint anchors

### DIFF
--- a/Source/iOS/Constraint.swift
+++ b/Source/iOS/Constraint.swift
@@ -1,0 +1,40 @@
+import UIKit
+
+public struct Constraint {
+
+  public static func on(constraints: [NSLayoutConstraint]) {
+    constraints.forEach {
+      ($0.firstItem as? UIView)?.translatesAutoresizingMaskIntoConstraints = false
+      $0.isActive = true
+    }
+  }
+}
+
+public extension UIView {
+
+  @available(iOS 9, *)
+  func pinCenter(view: UIView) {
+    Constraint.on(constraints: [
+      centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      centerYAnchor.constraint(equalTo: view.centerYAnchor)
+    ])
+  }
+
+  @available(iOS 9, *)
+  func pinEdges(view: UIView) {
+    Constraint.on(constraints: [
+      leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      topAnchor.constraint(equalTo: view.topAnchor),
+      bottomAnchor.constraint(equalTo: view.bottomAnchor)
+    ])
+  }
+
+  @available(iOS 9, *)
+  func pin(size: CGSize) {
+    Constraint.on(constraints: [
+      widthAnchor.constraint(equalToConstant: size.width),
+      heightAnchor.constraint(equalToConstant: size.height)
+    ])
+  }
+}

--- a/Sugar.xcodeproj/project.pbxproj
+++ b/Sugar.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		D20FF6321CD2029B000F3BFE /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20FF6301CD2029B000F3BFE /* String+Extension.swift */; };
 		D21D1B941CAE680F00BD068E /* TestDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21D1B931CAE680F00BD068E /* TestDate.swift */; };
 		D21D1B951CAE680F00BD068E /* TestDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21D1B931CAE680F00BD068E /* TestDate.swift */; };
+		D2EA3A8F1E38F6970038B04A /* Constraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EA3A8E1E38F6970038B04A /* Constraint.swift */; };
 		D2FD145F1CE5F27A00EC080B /* Double+DateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FD145E1CE5F27A00EC080B /* Double+DateTime.swift */; };
 		D2FD14601CE5F27A00EC080B /* Double+DateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FD145E1CE5F27A00EC080B /* Double+DateTime.swift */; };
 		D2FD14621CE5F30500EC080B /* TestDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FD14611CE5F30500EC080B /* TestDouble.swift */; };
@@ -207,6 +208,7 @@
 		D20FF62E1CD1FE6F000F3BFE /* TestUIImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestUIImage.swift; sourceTree = "<group>"; };
 		D20FF6301CD2029B000F3BFE /* String+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		D21D1B931CAE680F00BD068E /* TestDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDate.swift; sourceTree = "<group>"; };
+		D2EA3A8E1E38F6970038B04A /* Constraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constraint.swift; sourceTree = "<group>"; };
 		D2FD145E1CE5F27A00EC080B /* Double+DateTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Double+DateTime.swift"; sourceTree = "<group>"; };
 		D2FD14611CE5F30500EC080B /* TestDouble.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDouble.swift; sourceTree = "<group>"; };
 		D527ED9F1C9C0B7D0092AD6B /* UIDevice+Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIDevice+Model.swift"; sourceTree = "<group>"; };
@@ -320,6 +322,7 @@
 				BDA447A31C29470D003FDEAD /* Extensions */,
 				BDA447A51C29470D003FDEAD /* Screen.swift */,
 				BDA447A61C29470D003FDEAD /* Simulator.swift */,
+				D2EA3A8E1E38F6970038B04A /* Constraint.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -803,6 +806,7 @@
 				39D4BC221C9C2A6E005D6EC0 /* NSDate+Extensions.swift in Sources */,
 				BD81A14B1C73A596009955E3 /* Result.swift in Sources */,
 				BDA447B61C294723003FDEAD /* Array+Queueable.swift in Sources */,
+				D2EA3A8F1E38F6970038B04A /* Constraint.swift in Sources */,
 				BD9FDD3F1D2BDA900085F584 /* ConstraintKeyboardHandler.swift in Sources */,
 				BDA447B81C294723003FDEAD /* String+URLStringConvertible.swift in Sources */,
 				39D4BC281C9C2DDE005D6EC0 /* String+Validation.swift in Sources */,


### PR DESCRIPTION
As iOS 9 is coming to as the default minimum deployment target, we're starting to use `NSLayoutAnchor` and stop dropping other Auto Layout helper libraries. However, we will do 2 repetitive steps as we're using `NSLayoutAnchor`

- Activate the constraints
- Set `translatesAutoresizingMaskIntoConstraints` to false

which is very easy to forget and boilerplate. This makes it into Sugar.

Also, it also opens up discussions as what we will improve Sugar as of Swift 3 😎 