### PR TITLE
Fix bundle name

### DIFF
--- a/Source/Shared/Application.swift
+++ b/Source/Shared/Application.swift
@@ -15,7 +15,9 @@ public struct Application {
   }
 
   public static var name: String = {
-    return Application.getString("CFBundleDisplayName")
+    let displayName = Application.getString("CFBundleDisplayName")
+
+    return !displayName.isEmpty ? displayName : Application.getString("CFBundleName")
   }()
 
   public static var version: String = {


### PR DESCRIPTION
Fallback to `CFBundleName` in case `CFBundleDisplayName` is not specified in `Info.plist`