### PR TITLE
Swift 3 Date is comparable. These operators will conflict with Swift 3 operators.

### DIFF
--- a/Source/Shared/Extensions/NSDate+Extensions.swift
+++ b/Source/Shared/Extensions/NSDate+Extensions.swift
@@ -1,21 +1,5 @@
 import Foundation
 
-public func < (lhs: Date, rhs: Date) -> Bool {
-  return lhs.timeIntervalSince1970 < rhs.timeIntervalSince1970
-}
-
-public func <= (lhs: Date, rhs: Date) -> Bool {
-  return lhs.timeIntervalSince1970 <= rhs.timeIntervalSince1970
-}
-
-public func >= (lhs: Date, rhs: Date) -> Bool {
-  return lhs.timeIntervalSince1970 >= rhs.timeIntervalSince1970
-}
-
-public func > (lhs: Date, rhs: Date) -> Bool {
-  return lhs.timeIntervalSince1970 > rhs.timeIntervalSince1970
-}
-
 // MARK: - Components
 
 public extension Date {


### PR DESCRIPTION
If you use current Sugar with Swift 3 environment and use `>`, `<`, `>=`, `<=` operators, it will lead to compile error like follows. 

```
Ambiguous use of operator '<'
```

We shouldn't have these operators in Sugar anymore.