### PR TITLE
Check for content before apply templating

### DIFF
--- a/Source/iOS/Extensions/UIImage+RenderingMode.swift
+++ b/Source/iOS/Extensions/UIImage+RenderingMode.swift
@@ -2,11 +2,19 @@ import UIKit
 
 public extension UIImage {
 
-  public var original: UIImage {
+  public var original: UIImage? {
+    guard hasContent else {
+      return nil
+    }
+
     return withRenderingMode(.alwaysOriginal)
   }
 
-  public var template: UIImage {
+  public var template: UIImage? {
+    guard hasContent else {
+      return nil
+    }
+
     return withRenderingMode(.alwaysTemplate)
   }
 }

--- a/Tests/iOS/TestUIImage.swift
+++ b/Tests/iOS/TestUIImage.swift
@@ -8,4 +8,8 @@ class UIImageTests: XCTestCase {
     XCTAssertEqual(UIImage().hasContent, false)
     XCTAssertEqual(UIImage(color: UIColor.red).hasContent, true)
   }
+
+  func testContent() {
+    XCTAssertNil(UIImage().template)
+  }
 }


### PR DESCRIPTION
It can crashes if the image is not really an image