### PR TITLE
Remove sizes

### DIFF
--- a/Source/iOS/Extensions/UIDevice+Model.swift
+++ b/Source/iOS/Extensions/UIDevice+Model.swift
@@ -1,38 +1,6 @@
 import UIKit
 
 public extension UIDevice {
-
-  public enum DeviceKind {
-    case iPhone4
-    case iPhone5
-    case iPhone6
-    case iPhone6Plus
-    case iPad
-    case unknown
-  }
-
-  public var kind: DeviceKind {
-    guard userInterfaceIdiom == .phone else {
-      return .iPad
-    }
-
-    let result: DeviceKind
-
-    switch UIScreen.main.nativeBounds.height {
-    case 960:
-      result = .iPhone4
-    case 1136:
-      result = .iPhone5
-    case 1334:
-      result = .iPhone6
-    case 2208:
-      result = .iPhone6Plus
-    default:
-      result = .unknown
-    }
-
-    return result
-  }
     
   public static func isPhone() -> Bool {
     return UIDevice().userInterfaceIdiom == .phone


### PR DESCRIPTION
- As of https://github.com/onmyway133/blog/issues/59, we shouldn't use `nativeBounds`, as it is physical sizes, and devices also have `display mode`
- Also, this advocates users to depend on specific devices to layout, which is not good practice 🙄 
- Remove it 😄 