### PR TITLE
Swift 4 for img shield icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Sugar is a sweetener for your Cocoa implementations.
 [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![License](https://img.shields.io/cocoapods/l/Sugar.svg?style=flat)](http://cocoadocs.org/docsets/Sugar)
 [![Platform](https://img.shields.io/cocoapods/p/Sugar.svg?style=flat)](http://cocoadocs.org/docsets/Sugar)
-![Swift](https://img.shields.io/badge/%20in-swift%203.0-orange.svg)
+![Swift](https://img.shields.io/badge/%20in-swift%204.0-orange.svg)
 
 Table of Contents
 --


### PR DESCRIPTION
I found this nice library and at first I saw that it's for Swift 3 (icon) but in the end it's for Swift 4.0.